### PR TITLE
Extend (cons x y) to cases x=y and y=(length ...)

### DIFF
--- a/cl-slice-dev.lisp
+++ b/cl-slice-dev.lisp
@@ -36,7 +36,7 @@
   "Canonical representation of a contiguous set of array indices from START (inclusive) to END (exclusive)."
   (assert (and (typep start 'array-index)
                (typep end 'array-index)
-               (< start end)))
+               (<= start end)))
   (make-canonical-range :start start :end end))
 
 (defstruct canonical-sequence
@@ -84,7 +84,7 @@ Unless a specialized method is found, the dimension of the axis is queried with 
          (aprog1 (+ axis slice)
            (assert (<= 0 it)))
          (aprog1 slice
-           (assert (< slice axis))))))
+           (assert (<= slice axis))))))
   (:method (axis (slice cons))
     (let+ (((start . end) slice)
            (start (canonical-representation axis start))

--- a/cl-slice-tests.lisp
+++ b/cl-slice-tests.lisp
@@ -41,7 +41,12 @@
   (assert-condition error (slice vec10 #*00)) ; too short
   ;; vectors containing other forms
   (assert-equalp #(1 2 6 8)
-      (slice #(0 1 2 3 4 5 6 7 8 9) (vector (cons 1 3) 6 (cons -2 -1)))))
+      (slice #(0 1 2 3 4 5 6 7 8 9) (vector (cons 1 3) 6 (cons -2 -1))))
+  (assert-equalp #(1 2 6 8 9)
+      (slice #(0 1 2 3 4 5 6 7 8 9) (vector (cons 1 3) 6 (cons 8 10))))
+  ;; empty slice
+  (assert-equalp #(6 8)
+      (slice #(0 1 2 3 4 5 6 7 8 9) (vector (cons 0 0) 6 (cons -2 -1)))))
 
 (deftest test-convenience-forms (representation-suite)
   (assert-equalp #(3 4 5) (slice vec10 (including 3 5)))


### PR DESCRIPTION
Previously, (cons 3 3) was an error. Now it's nil.

Previously, (cons 3 nil) would represent the slice the 4th element to
the element of the object, (cons 3 (length obj)) would be an
error. Now the two are identical.
